### PR TITLE
Added "source" step to README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,17 +13,25 @@ INSTALLATION
 
   /data/Wing/bin/setup/setup.sh
 
- NOTE: If you're trying to install DBD::mysql on Mac and it's giving you trouble, make sure you do first:
+  NOTE: If you're trying to install DBD::mysql on Mac and it's giving you trouble, make sure you do first:
 
   export DYLD_LIBRARY_PATH=/usr/local/mysql/lib:$DYLD_LIBRARY_PATH
 
-3. Create a project in /data/MyApp:
+3. Verify/set apps paths.
+
+  perl -v  # should return 5.16.2, the version required by Wing.  If not:
+  source /data/Wing/bin/dataapps.sh
+  perl -v  # should return 5.16.2
+
+4. Create a project in /data/MyApp:
 
   cd /data/Wing/bin
   export WING_HOME=/data/Wing
   perl wing_init_app.pl --app=MyApp
 
-4. Create a database on your MySQL server to host the project, and edit the Wing config to match:
+  NOTE: If you get an error a la "Illegal division by zero" from warnings.pm in this step, revisit step 3.
+
+5. Create a database on your MySQL server to host the project, and edit the Wing config to match:
 
   mysql -uroot -p -e "create database my_project"
   mysql -uroot -p -e "grant all privileges on my_project.* to some_user@localhost identified by 'some_pass'" 
@@ -32,7 +40,7 @@ INSTALLATION
   vi /data/MyApp/etc/wing.conf  
   # edit the "db" section and add the username and password.
 
-5. Initialize the database:
+6. Initialize the database:
 
   cd /data/MyApp/bin
   export WING_HOME=/data/Wing
@@ -42,33 +50,33 @@ INSTALLATION
   wing db --prepare_install
   wing db --install --force
 
-6. Start up the rest server and/or web server:
+7. Start up the rest server and/or web server:
 
   cd /data/MyApp/bin
   ./start_rest.sh
   ./start_web.sh
 
-7. Now you can connect to the rest server and see if it's alive:
+8. Now you can connect to the rest server and see if it's alive:
 
-   curl http://localhost:5000/api/status
+  curl http://localhost:5000/api/status
 
-   curl http://localhost:5001/account
+  curl http://localhost:5001/account
 
- NOTE: By default there is one user named 'Admin' with a password of '123qwe'.
+  NOTE: By default there is one user named 'Admin' with a password of '123qwe'.
 
-8. We also provide you with an nginx config file to give you a baseline for serving your apps. You can start it like this:
+9. We also provide you with an nginx config file to give you a baseline for serving your apps. You can start it like this:
 
- nginx -c /data/MyApp/etc/nginx.conf
+  nginx -c /data/MyApp/etc/nginx.conf
 
- NOTE: This is required to merge together the two services, as well as serve up static files.
+  NOTE: This is required to merge together the two services, as well as serve up static files.
 
- WARNING: There is no "home" page. Wing is expecting you to create it. After you start Nginx you'll be able to access /account and /admin. Everything is will 404. 
+  WARNING: There is no "home" page. Wing is expecting you to create it. After you start Nginx you'll be able to access /account and /admin. Everything is will 404. 
 
 ADDING FUNCTIONALITY
 
 We also provide you with tools to build out your app. For example, if you want to add a new class to your app, you can:
 
- wing class --add=NewObject
+  wing class --add=NewObject
  
 This will dynamically generate a NewObject.pm class file for you in /data/MyApp/lib/MyApp/DB/Result/, and create a Rest
 interface at /data/MyApp/lib/MyApp/Rest/NewObject.pm, and create a Web interface at /data/MyApp/lib/MyApp/Web/NewObject.pm.
@@ -76,22 +84,22 @@ It will even add the lines needed in /data/MyApp/bin/rest.psgi and /data/MyApp/b
 
 To upgrade your database with the schema changes for your new class:
 
- increment the database version number in MyApp::DB
- wing db --prepare
- wing db --upgrade
+  increment the database version number in MyApp::DB
+  wing db --prepare
+  wing db --upgrade
 
 For more information on managing the database schema see the DBIx::Class::DeploymentHandler documentation.
 
 Once you've built out your object and you're ready to generate some web templates for it you can do:
 
- wing class --template=NewObject
+  wing class --template=NewObject
  
 That will add templates in /data/MyApp/views/newobject/*.tt. 
 
 
 For more information type:
 
- perldoc lib/Wing/FirstApp.pod
+  perldoc lib/Wing/FirstApp.pod
 
 
 

--- a/bin/wing_init_app.pl
+++ b/bin/wing_init_app.pl
@@ -33,6 +33,7 @@ $new_config->config($config->config);
 $new_config->set('mkits', '/data/'.$project.'/var/mkits/');
 $new_config->set('app_namespace', $project);
 $new_config->set("log4perl_config", "/data/".$project."/etc/log4perl.conf",);
+$new_config->get( 'db' )->[ 0 ] =~ s|PROJECT|lc( $project )|e;
 $new_config->write;
 
 # set up dancer config
@@ -105,6 +106,8 @@ system('cd /data/'.$project.'/bin;chmod 755 *');
 say "Be sure to export the environment variables you need for your app:\n";
 say "export WING_APP=/data/".$project;
 say "export WING_CONFIG=/data/".$project."/etc/wing.conf";
+say 'database name set to ' . lc( $project );
+say qq|for create database step, run command 'mysql -uroot -p -e "create database @{[ lc( $project ) ]}"'|;
 
 sub template {
   my ($tt, $from, $vars, $to) = @_;


### PR DESCRIPTION
Added setup step per PerlDreamer's request to README and tidied indentation.

Also changed wing app init script to automatically add db name (lc'ed app name) to new app wing conf; user is also alerted to proper "create database" command for following step.
