### PR TITLE
Keep Markdown links intact

### DIFF
--- a/author.t/contentfilter_markdown_link.t
+++ b/author.t/contentfilter_markdown_link.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+BEGIN {
+    unshift @INC, "$ENV{WING_APP}/lib" if $ENV{WING_APP};
+}
+use Test::More;
+
+use Wing::ContentFilter;
+
+my $markdown_link = '[https://protospiel.online/designchallenge](https://protospiel.online/designchallenge)';
+Wing::ContentFilter::format_markdown(\$markdown_link);
+
+{
+    no warnings 'redefine';
+    local *Wing::ContentFilter::format_link = sub {
+        my $uri = shift;
+        return '<enriched>'.$uri->as_string.'</enriched>';
+    };
+    Wing::ContentFilter::find_and_format_uris(\$markdown_link, { links => 1 });
+}
+
+is $markdown_link,
+    '<p><a href="https://protospiel.online/designchallenge">https://protospiel.online/designchallenge</a></p>',
+    'does not enrich a URL already inside a Markdown link';
+
+my $mixed_links = '<p><a href="https://example.com/kept">Kept link</a> and https://example.com/enriched</p>';
+my $found;
+{
+    no warnings 'redefine';
+    local *Wing::ContentFilter::format_link = sub {
+        my $uri = shift;
+        return '<enriched>'.$uri->as_string.'</enriched>';
+    };
+    $found = Wing::ContentFilter::find_and_format_uris(\$mixed_links, { links => 1 });
+}
+
+is $mixed_links,
+    '<p><a href="https://example.com/kept">Kept link</a> and <enriched>https://example.com/enriched</enriched></p>',
+    'still enriches a bare URL outside an existing link';
+is $found, 1, 'reports only the bare URL as found';
+
+done_testing;

--- a/lib/Wing/ContentFilter.pm
+++ b/lib/Wing/ContentFilter.pm
@@ -77,6 +77,7 @@ sub find_and_format_uris {
     my ($content, $allowed) = @_;
     my $finder = URI::Find::Delimited->new(
         delimiter_re  => [ '\(', '\)' ], # ignore markdown urls
+        ignore_quoted => 1,
         callback => sub {
             my ($opening_delim, $closing_delim, $uri_string, $title, $whitespace) = @_;
 
@@ -129,7 +130,14 @@ sub find_and_format_uris {
             }
         },
     );
-    $finder->find($content);
+    my @segments = split m{(<a\b[^>]*>.*?</a>)}is, ${$content};
+    my $urls_found = 0;
+    foreach my $segment (@segments) {
+        next if $segment =~ m{\A<a\b[^>]*>.*?</a>\z}is;
+        $urls_found += $finder->find(\$segment);
+    }
+    ${$content} = join '', @segments;
+    return $urls_found;
 }
 
 sub format_link {

--- a/lib/Wing/Role/Result/WebFilteredField.pm
+++ b/lib/Wing/Role/Result/WebFilteredField.pm
@@ -34,11 +34,10 @@ sub wing_webfiltered_field {
             if (defined $value) {
                 my $html = $value;
                 Wing::ContentFilter::format_html(\$html, exists $options->{format_html} ? $options->{format_html} : { entities => 1, with_markdown => $options->{use_markdown} });
-                Wing::ContentFilter::find_and_format_uris(\$html, exists $options->{find_and_format_uris} ? $options->{find_and_format_uris} : { youtube => 1, links => 1, images => 1, vimeo => 1});
-
                 if ($options->{use_markdown}) {
                     Wing::ContentFilter::format_markdown(\$html);
                 }
+                Wing::ContentFilter::find_and_format_uris(\$html, exists $options->{find_and_format_uris} ? $options->{find_and_format_uris} : { youtube => 1, links => 1, images => 1, vimeo => 1});
                 $self->$field_html($html);
             }
         });


### PR DESCRIPTION
## What this improves

Links written with a label and destination now stay as one valid link. Pasted web addresses outside a link still receive the usual helpful formatting.

This prevents the broken, nested link shown in plainblack/TGC#2771.

## Checks

- Added the exact example from the ticket; it failed before the change and now passes.
- Confirmed that an ordinary pasted address is still formatted normally.
- Saved the example on a local game and checked the public game page through the normal site address.

Resolves plainblack/TGC#2771
