### PR TITLE
Rotate Algolia hosts after write failures

### DIFF
--- a/author.t/algolia_host_rotation.t
+++ b/author.t/algolia_host_rotation.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use HTTP::Response;
+
+BEGIN {
+    package TestAlgoliaConfig;
+
+    sub get {
+        return {
+            application_id => 'test-application',
+            admin_key      => 'test-admin-key',
+            public_key     => 'test-public-key',
+        };
+    }
+
+    package TestAlgoliaLog;
+
+    sub debug { }
+    sub error { }
+    sub info  { }
+
+    package Wing;
+
+    my $config = bless {}, 'TestAlgoliaConfig';
+    my $log    = bless {}, 'TestAlgoliaLog';
+
+    sub config { return $config; }
+    sub log    { return $log; }
+
+    $INC{'Wing.pm'} = __FILE__;
+}
+
+use Wing::Algolia;
+
+my @requested_hosts;
+my $request_count = 0;
+
+{
+    no warnings qw(redefine once);
+    local *LWP::UserAgent::new = sub { return bless {}, 'TestAlgoliaUserAgent'; };
+    local *TestAlgoliaUserAgent::request = sub {
+        my ($self, $request) = @_;
+        push @requested_hosts, $request->uri->host;
+        $request_count++;
+        return HTTP::Response->new($request_count == 1 ? 500 : 200);
+    };
+
+    my $algolia = Wing::Algolia->new;
+    ok $algolia->delete_index_object('products', 'object-id'),
+        'write succeeds when the fallback host responds';
+}
+
+is_deeply \@requested_hosts, [
+    'test-application.algolia.net',
+    'test-application-1.algolianet.com',
+], 'a failed primary write is retried against the next configured host';
+
+done_testing();

--- a/lib/Wing/Algolia.pm
+++ b/lib/Wing/Algolia.pm
@@ -45,14 +45,10 @@ has url_index => (
     default => 0,
 );
 
-has base_url => (
-    is      => 'ro',
-    lazy    => 1,
-    default => sub {
-        my $self = shift;
-        return $self->url_options->[$self->url_index];
-    },
-);
+sub base_url {
+    my $self = shift;
+    return $self->url_options->[$self->url_index];
+}
 
 has headers => (
     is      => 'ro',


### PR DESCRIPTION
## Summary

- resolve the Algolia hostname from the current `url_index` for every request
- cover a primary timeout followed by a successful fallback with a mocked regression test

## TDD evidence

- Red: `prove -lv author.t/algolia_host_rotation.t` recorded both requests against `test-application.algolia.net`
- Green: the same command passes and records the second request against `test-application-1.algolianet.com`
- `git diff --check`

Fixes #34
Related: plainblack/TGC#3643
