### PR TITLE
Limit Algolia writes to configured hosts

### DIFF
--- a/author.t/algolia_retry_limit.t
+++ b/author.t/algolia_retry_limit.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use HTTP::Response;
+
+BEGIN {
+    package TestAlgoliaConfig;
+
+    sub get {
+        return {
+            application_id => 'test-application',
+            admin_key      => 'test-admin-key',
+            public_key     => 'test-public-key',
+        };
+    }
+
+    package TestAlgoliaLog;
+
+    sub debug { }
+    sub error { }
+    sub info  { }
+
+    package Wing;
+
+    my $config = bless {}, 'TestAlgoliaConfig';
+    my $log    = bless {}, 'TestAlgoliaLog';
+
+    sub config { return $config; }
+    sub log    { return $log; }
+
+    $INC{'Wing.pm'} = __FILE__;
+}
+
+use Wing::Algolia;
+
+my $request_count = 0;
+my $completed;
+
+{
+    no warnings qw(redefine once);
+    local *LWP::UserAgent::new = sub { return bless {}, 'TestAlgoliaUserAgent'; };
+    local *TestAlgoliaUserAgent::request = sub {
+        $request_count++;
+        return HTTP::Response->new(500);
+    };
+
+    my $algolia = Wing::Algolia->new;
+    $completed = eval {
+        $algolia->delete_index_object('products', 'object-id');
+        1;
+    };
+}
+
+ok !$completed, 'write fails after all configured hosts fail';
+like $@, qr/Error updating search index/, 'write reports the Algolia failure';
+is $request_count, 4, 'four configured hosts limit the operation to four HTTP attempts';
+
+done_testing();

--- a/lib/Wing/Algolia.pm
+++ b/lib/Wing/Algolia.pm
@@ -105,7 +105,7 @@ sub make_request {
     my $response = $ua->request($request);
     if (! $response->is_success) {
 	my $url_option_count = scalar(@{$self->url_options});
-	if ($retry_count >= $url_option_count) {
+	if ($retry_count + 1 >= $url_option_count) {
 		Wing->log->error("ALGOLIA FAILURE");
 		Wing->log->debug("Request: ". $request->as_string);
 		Wing->log->debug("Response: ". $response->as_string);


### PR DESCRIPTION
## Summary

- treat the configured Algolia host count as the maximum total attempt count
- stop after four failed requests instead of wrapping to a fifth request against the primary host
- cover the failure limit with a mocked regression test

## TDD evidence

- Red: `prove -lv author.t/algolia_retry_limit.t` observed 5 requests with 4 configured hosts
- Green: the same command passes with exactly 4 requests
- `git diff --check`

Fixes #35
Related: plainblack/TGC#3643
