### PR TITLE
Support absolute badge session expiration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ This file tracks the changes to Wing over time. Especially
 with respect to new features and compatibility changes.
 ==========================================================
 
+2026-08-17
+ * Preserve absolute session expirations and authentication metadata when legacy requests extend a session, and reject revoked TGC Floor badge logins.
+
 2026-08-14
  * Fix a bug with host rotation when doing Algolia writes.
  * Fix a bug with retry counts and wrapping back to the original host.  Fixes #35

--- a/author.t/session_absolute_expiry.t
+++ b/author.t/session_absolute_expiry.t
@@ -1,0 +1,118 @@
+use strict;
+use warnings;
+use Test::More;
+use lib 'lib';
+use Wing::Session;
+
+{
+    package Local::SessionCache;
+
+    sub new {
+        return bless { values => {}, ttls => {} }, shift;
+    }
+
+    sub get {
+        my ($self, $key) = @_;
+        return $self->{values}{$key};
+    }
+
+    sub set {
+        my ($self, $key, $value, $ttl) = @_;
+        $self->{values}{$key} = $value;
+        $self->{ttls}{$key} = $ttl;
+        return 1;
+    }
+
+    sub remove {
+        my ($self, $key) = @_;
+        delete $self->{values}{$key};
+        delete $self->{ttls}{$key};
+        return 1;
+    }
+}
+
+{
+    package Local::SessionUser;
+
+    sub new { return bless {}, shift }
+    sub id { return 'user-1' }
+    sub password { return 'password-hash' }
+    sub permanently_deactivated { return 0 }
+    sub current_session { return }
+    sub user_to_json { return { id => 'user-1' } }
+}
+
+{
+    package Local::SessionDb;
+}
+
+my $cache = Local::SessionCache->new;
+my $user = Local::SessionUser->new;
+my $absolute_expires_at = time + 4 * 60 * 60;
+$cache->set(
+    'floor-active-login-user-1',
+    { floorLoginId => 'floor-login-1', sessionIds => [] },
+    4 * 60 * 60,
+);
+
+{
+    no warnings qw(redefine once);
+    local *Wing::cache = sub { return $cache };
+
+    my $session = Wing::Session->new(
+        id => 'floor-session',
+        db => bless({}, 'Local::SessionDb'),
+    );
+    $session->start($user, {
+        sso => 0,
+        ip_address => '127.0.0.1',
+        auth_source => 'floor_badge',
+        floor_login_id => 'floor-login-1',
+        absolute_expires_at => $absolute_expires_at,
+    });
+
+    my $stored = $cache->get('session-floor-session');
+    is($stored->{auth_source}, 'floor_badge', 'stores the badge authentication source');
+    is($stored->{floor_login_id}, 'floor-login-1', 'stores the originating Floor login');
+    is(
+        $stored->{absolute_expires_at},
+        $absolute_expires_at,
+        'stores the absolute session expiration',
+    );
+    cmp_ok(
+        $cache->{ttls}{'session-floor-session'},
+        '<=',
+        4 * 60 * 60,
+        'does not cache the session beyond the absolute expiration',
+    );
+
+    my $reloaded = Wing::Session->new(
+        id => 'floor-session',
+        db => bless({}, 'Local::SessionDb'),
+    );
+    is($reloaded->auth_source, 'floor_badge', 'reloads the authentication source');
+    is($reloaded->floor_login_id, 'floor-login-1', 'reloads the Floor login id');
+    is(
+        $reloaded->absolute_expires_at,
+        $absolute_expires_at,
+        'reloads the absolute expiration',
+    );
+
+    $reloaded->user($user);
+    $reloaded->extend;
+    is(
+        $cache->get('session-floor-session')->{absolute_expires_at},
+        $absolute_expires_at,
+        'preserves the absolute expiration when legacy traffic extends the session',
+    );
+
+    $cache->remove('floor-active-login-user-1');
+    my $revoked = Wing::Session->new(
+        id => 'floor-session',
+        db => bless({}, 'Local::SessionDb'),
+    );
+    ok(!$revoked->has_user_id, 'rejects a badge session after its Floor login is revoked');
+    ok(!$cache->get('session-floor-session'), 'removes the revoked badge session');
+}
+
+done_testing;

--- a/lib/Wing/Session.pm
+++ b/lib/Wing/Session.pm
@@ -50,6 +50,10 @@ sub BUILD {
         $self->ip_address($session_data->{ip_address});
         $self->sso($session_data->{sso});
         $self->api_key_id($session_data->{api_key_id});
+        $self->auth_source($session_data->{auth_source}) if exists $session_data->{auth_source};
+        $self->floor_login_id($session_data->{floor_login_id}) if exists $session_data->{floor_login_id};
+        $self->absolute_expires_at($session_data->{absolute_expires_at}) if exists $session_data->{absolute_expires_at};
+        $self->reject_inactive_floor_login unless $self->floor_login_is_active;
     }
 }
 
@@ -72,9 +76,25 @@ has sso => (
     default     => 0,
 );
 
+has auth_source => (
+    is          => 'rw',
+    predicate   => 'has_auth_source',
+);
+
+has floor_login_id => (
+    is          => 'rw',
+    predicate   => 'has_floor_login_id',
+);
+
+has absolute_expires_at => (
+    is          => 'rw',
+    predicate   => 'has_absolute_expires_at',
+);
+
 has user_id => (
     is          => 'rw',
     predicate   => 'has_user_id',
+    clearer     => 'clear_user_id',
     trigger     => sub {
         my $self = shift;
         $self->clear_user;
@@ -146,8 +166,44 @@ sub check_permissions {
     return 1;
 }
 
+sub floor_login_is_active {
+    my $self = shift;
+    return 1 unless $self->has_auth_source && $self->auth_source eq 'floor_badge';
+    return 0 unless $self->has_user_id && $self->has_floor_login_id;
+    return 0 if $self->has_absolute_expires_at && $self->absolute_expires_at <= time;
+
+    my $active = Wing->cache->get('floor-active-login-' . $self->user_id);
+    return defined $active
+        && ref $active eq 'HASH'
+        && defined $active->{floorLoginId}
+        && $active->{floorLoginId} eq $self->floor_login_id;
+}
+
+sub reject_inactive_floor_login {
+    my $self = shift;
+    Wing->cache->remove($self->key);
+    $self->clear_user;
+    $self->clear_user_id;
+    return;
+}
+
 sub extend {
     my $self = shift;
+
+    unless ($self->floor_login_is_active) {
+        $self->reject_inactive_floor_login;
+        return;
+    }
+
+    my $ttl = 60 * 60 * 24 * 7;
+    if ($self->has_absolute_expires_at) {
+        my $remaining = int($self->absolute_expires_at - time);
+        if ($remaining <= 0) {
+            $self->end;
+            return;
+        }
+        $ttl = $remaining if $remaining < $ttl;
+    }
     
     # Check if user data has changed
     my $user_changed_key = 'user-changed-' . $self->user_id;
@@ -184,9 +240,7 @@ sub extend {
         return;
     }
     $self->extended( $self->extended + 1 );
-    Wing->cache->set(
-        $self->key,
-        {
+    my $session_data = {
             password_hash    => $self->password_hash, # this hash is stored here so that if the user changes their password we can log out all existing sessions
             user_id     => $self->user_id,
             extended    => $self->extended,
@@ -195,9 +249,11 @@ sub extend {
             ip_address  => $self->ip_address,
             session_id  => $self->id,
             user_data   => $self->user->user_to_json,
-        },
-        60 * 60 * 24 * 7,
-    );
+    };
+    $session_data->{auth_source} = $self->auth_source if $self->has_auth_source;
+    $session_data->{floor_login_id} = $self->floor_login_id if $self->has_floor_login_id;
+    $session_data->{absolute_expires_at} = $self->absolute_expires_at if $self->has_absolute_expires_at;
+    Wing->cache->set($self->key, $session_data, $ttl);
     return $self;
 }
 
@@ -224,6 +280,9 @@ sub start {
     $self->sso($options->{sso});
     $self->ip_address($options->{ip_address});
     $self->api_key_id($options->{api_key_id});
+    $self->auth_source($options->{auth_source}) if exists $options->{auth_source};
+    $self->floor_login_id($options->{floor_login_id}) if exists $options->{floor_login_id};
+    $self->absolute_expires_at($options->{absolute_expires_at}) if exists $options->{absolute_expires_at};
     return $self->extend;
 }
 


### PR DESCRIPTION
## Summary
- preserve Floor badge authentication metadata when legacy Wing requests extend sessions
- cap cache lifetime at the session absolute expiration
- reject badge sessions when the originating Floor login is no longer active

## Tests
- `prove -lv author.t/session_absolute_expiry.t`
- `perl -Ilib -c lib/Wing/Session.pm`

## Dependency
Companion to plainblack/TGC#3656. Merge/deploy this Wing change before enabling the Floor launcher.